### PR TITLE
Fix footer overlapping content. Add margins to home-button-container

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -139,7 +139,7 @@ hr {
 
 #home-button-container {
     text-align: center;
-    margin-top: 20px;
+    margin: 20px 0px;
 }
 
 #home-button {
@@ -152,7 +152,9 @@ hr {
 footer {
     background-color: #FFCA00;
     color: #0E0F13;
-    padding: 5px 0;
+    padding: 10px 0;
+    bottom: 0;
+    
 }
 
 /* Styles social media icons */

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     </div>
 
     <!-- Footer-->
-    <footer class="container-fluid fixed-bottom">
+    <footer class="container-fluid">
         <!-- Social media icons -->
         <div class="text-center">
             <a href="https://www.facebook.com/" target="_blank" rel="noopener"


### PR DESCRIPTION
Footer was overlapping content.

Delete fixed-position from footer class.
Added margin to top and bottom of home-button-container so there would be nicer spacing.